### PR TITLE
[UPD] ssi_fixed_asset: Mekanisme aset tanah tanpa depresiasi

### DIFF
--- a/ssi_fixed_asset/models/fixed_asset_asset.py
+++ b/ssi_fixed_asset/models/fixed_asset_asset.py
@@ -469,6 +469,13 @@ class FixedAssetAsset(models.Model):
         string="Analytic account",
         comodel_name="account.analytic.account",
     )
+    no_depreciation = fields.Boolean(
+        string="No Depreciation",
+        related="category_id.no_depreciation",
+        store=True,
+        compute_sudo=True,
+        help="Indicates that this asset does not require depreciation.",
+    )
 
     def _get_method_time_coefficient(self):
         self.ensure_one()
@@ -1080,8 +1087,14 @@ class FixedAssetAsset(models.Model):
         table = table[: i_max + 1]
         return table
 
+    def _should_skip_compute_depreciation_board(self):
+        self.ensure_one()
+        return self.no_depreciation
+
     def compute_depreciation_board(self):
         for asset in self.sudo():
+            if asset._should_skip_compute_depreciation_board():
+                continue
             if asset.value_residual == 0.0:
                 continue
             asset._delete_unposted_history()
@@ -1505,15 +1518,25 @@ class FixedAssetAsset(models.Model):
         obj_asset_category = self.env["fixed.asset.category"]
         if self.category_id:
             category = obj_asset_category.browse(self.category_id.id)
-            self.method = category.method
-            self.method_number = category.method_number
-            self.method_time = category.method_time
-            self.method_period = category.method_period
-            self.method_progress_factor = category.method_progress_factor
-            self.prorata = category.prorata
             self.account_analytic_id = category.account_analytic_id.id
-            self.date_min_prorate = category.date_min_prorate
-            self.prorate_by_month = True
+            if category.no_depreciation:
+                self.method = "linear"
+                self.method_number = 0
+                self.method_time = "year"
+                self.method_period = "year"
+                self.method_progress_factor = 0.3
+                self.prorata = False
+                self.date_min_prorate = 15
+                self.prorate_by_month = True
+            else:
+                self.method = category.method
+                self.method_number = category.method_number
+                self.method_time = category.method_time
+                self.method_period = category.method_period
+                self.method_progress_factor = category.method_progress_factor
+                self.prorata = category.prorata
+                self.date_min_prorate = category.date_min_prorate
+                self.prorate_by_month = True
 
     @api.onchange(
         "category_id",

--- a/ssi_fixed_asset/models/fixed_asset_category.py
+++ b/ssi_fixed_asset/models/fixed_asset_category.py
@@ -58,22 +58,26 @@ class FixedAssetCategory(models.Model):
     account_depreciation_id = fields.Many2one(
         string="Depreciation Account",
         comodel_name="account.account",
-        required=True,
         domain=[("internal_type", "=", "other")],
     )
     account_expense_depreciation_id = fields.Many2one(
         string="Depr. Expense Account",
         comodel_name="account.account",
-        required=True,
         domain=[("internal_type", "=", "other")],
     )
     journal_id = fields.Many2one(
         string="Journal",
         comodel_name="account.journal",
-        required=True,
         domain=[
             ("type", "=", "general"),
         ],
+    )
+    no_depreciation = fields.Boolean(
+        string="No Depreciation",
+        default=False,
+        help="Check this if the asset category does not require depreciation "
+        "(e.g. land). When enabled, depreciation accounts and journal "
+        "are not required.",
     )
     method = fields.Selection(
         string="Computation Method",
@@ -135,6 +139,34 @@ class FixedAssetCategory(models.Model):
         string="Date Min. to Prorate",
         default=15,
     )
+
+    @api.constrains(
+        "no_depreciation",
+        "journal_id",
+        "account_depreciation_id",
+        "account_expense_depreciation_id",
+    )
+    def _check_depreciation_accounts(self):
+        for rec in self:
+            if not rec.no_depreciation:
+                if not rec.journal_id:
+                    raise UserError(
+                        _("Journal is required for depreciable asset categories.")
+                    )
+                if not rec.account_depreciation_id:
+                    raise UserError(
+                        _(
+                            "Depreciation Account is required "
+                            "for depreciable asset categories."
+                        )
+                    )
+                if not rec.account_expense_depreciation_id:
+                    raise UserError(
+                        _(
+                            "Depr. Expense Account is required "
+                            "for depreciable asset categories."
+                        )
+                    )
 
     @api.constrains(
         "method",

--- a/ssi_fixed_asset/tests/__init__.py
+++ b/ssi_fixed_asset/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_fixed_asset
+from . import test_no_depreciation

--- a/ssi_fixed_asset/tests/test_data_no_depreciation.yaml
+++ b/ssi_fixed_asset/tests/test_data_no_depreciation.yaml
@@ -1,0 +1,235 @@
+scenarios:
+  - name: "No Depreciation Category - Create tanpa akun depresiasi"
+    steps:
+      - step: "Create asset account"
+        action: "create"
+        model: "account.account"
+        save_as: "account_asset"
+        values:
+          name: "Test Asset Account ND1"
+          code: "TND1_A01"
+          user_type_id: "REF: account.data_account_type_non_current_assets"
+          internal_type: "other"
+
+      - step: "Create no_depreciation category"
+        action: "create"
+        model: "fixed.asset.category"
+        save_as: "category"
+        values:
+          name: "Land Category ND1"
+          code: "TND1_C01"
+          no_depreciation: true
+          account_asset_id: "EVAL: registry['account_asset'].id"
+
+      - step: "Assert no_depreciation category berhasil dibuat"
+        action: "assert"
+        target: "category"
+        asserts:
+          no_depreciation:
+            type: "value"
+            expected: true
+          id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "No Depreciation Asset - Field no_depreciation ter-propagate dari kategori"
+    steps:
+      - step: "Create asset account"
+        action: "create"
+        model: "account.account"
+        save_as: "account_asset"
+        values:
+          name: "Test Asset Account ND2"
+          code: "TND2_A01"
+          user_type_id: "REF: account.data_account_type_non_current_assets"
+          internal_type: "other"
+
+      - step: "Create no_depreciation category"
+        action: "create"
+        model: "fixed.asset.category"
+        save_as: "category"
+        values:
+          name: "Land Category ND2"
+          code: "TND2_C01"
+          no_depreciation: true
+          account_asset_id: "EVAL: registry['account_asset'].id"
+
+      - step: "Create aset tanah"
+        action: "create"
+        model: "fixed.asset.asset"
+        save_as: "asset"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Land Asset ND2"
+          category_id: "EVAL: registry['category'].id"
+          purchase_value: 5000000000.0
+          date_start: 2024-01-01
+          type: "normal"
+          method: "linear"
+          method_time: "year"
+          method_number: 0
+          method_period: "year"
+
+      - step: "Assert no_depreciation ter-set pada aset"
+        action: "assert"
+        target: "asset"
+        asserts:
+          no_depreciation:
+            type: "value"
+            expected: true
+
+  - name:
+      "No Depreciation Asset - compute_depreciation_board tidak menghasilkan baris
+      depresiasi"
+    steps:
+      - step: "Create asset account"
+        action: "create"
+        model: "account.account"
+        save_as: "account_asset"
+        values:
+          name: "Test Asset Account ND3"
+          code: "TND3_A01"
+          user_type_id: "REF: account.data_account_type_non_current_assets"
+          internal_type: "other"
+
+      - step: "Create no_depreciation category"
+        action: "create"
+        model: "fixed.asset.category"
+        save_as: "category"
+        values:
+          name: "Land Category ND3"
+          code: "TND3_C01"
+          no_depreciation: true
+          account_asset_id: "EVAL: registry['account_asset'].id"
+
+      - step: "Create aset tanah"
+        action: "create"
+        model: "fixed.asset.asset"
+        save_as: "asset"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Land Asset ND3"
+          category_id: "EVAL: registry['category'].id"
+          purchase_value: 5000000000.0
+          date_start: 2024-01-01
+          type: "normal"
+          method: "linear"
+          method_time: "year"
+          method_number: 0
+          method_period: "year"
+
+      - step: "Panggil compute_depreciation_board"
+        action: "call"
+        target: "asset"
+        method: "compute_depreciation_board"
+        as_user: "base.user_admin"
+
+      - step: "Assert hanya ada 1 baris (type=create, bukan depreciate)"
+        action: "assert"
+        target: "asset"
+        asserts:
+          depreciation_line_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+  - name: "No Depreciation Asset - Full workflow draft to open tanpa error"
+    steps:
+      - step: "Create asset account"
+        action: "create"
+        model: "account.account"
+        save_as: "account_asset"
+        values:
+          name: "Test Asset Account ND4"
+          code: "TND4_A01"
+          user_type_id: "REF: account.data_account_type_non_current_assets"
+          internal_type: "other"
+
+      - step: "Create no_depreciation category"
+        action: "create"
+        model: "fixed.asset.category"
+        save_as: "category"
+        values:
+          name: "Land Category ND4"
+          code: "TND4_C01"
+          no_depreciation: true
+          account_asset_id: "EVAL: registry['account_asset'].id"
+
+      - step: "Create aset tanah"
+        action: "create"
+        model: "fixed.asset.asset"
+        save_as: "asset"
+        as_user: "base.user_admin"
+        values:
+          name: "Test Land Asset ND4"
+          category_id: "EVAL: registry['category'].id"
+          purchase_value: 5000000000.0
+          date_start: 2024-01-01
+          type: "normal"
+          method: "linear"
+          method_time: "year"
+          method_number: 0
+          method_period: "year"
+
+      - step: "Assert state awal = draft"
+        action: "assert"
+        target: "asset"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+      - step: "Confirm aset"
+        action: "call"
+        target: "asset"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate cache setelah confirm"
+        action: "call"
+        target: "asset"
+        method: "invalidate_cache"
+
+      - step: "Assert state = confirm"
+        action: "assert"
+        target: "asset"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve aset"
+        action: "call"
+        target: "asset"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate cache setelah approve"
+        action: "call"
+        target: "asset"
+        method: "invalidate_cache"
+
+      - step: "Assert state = open"
+        action: "assert"
+        target: "asset"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert no_depreciation masih true setelah open"
+        action: "assert"
+        target: "asset"
+        asserts:
+          no_depreciation:
+            type: "value"
+            expected: true
+
+      - step: "Assert tetap hanya ada 1 depreciation line (type=create)"
+        action: "assert"
+        target: "asset"
+        asserts:
+          depreciation_line_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1

--- a/ssi_fixed_asset/tests/test_no_depreciation.py
+++ b/ssi_fixed_asset/tests/test_no_depreciation.py
@@ -1,0 +1,39 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import Form, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestNoDepreciation(YamlTransactionCase):
+    def test_no_depreciation(self):
+        self.run_yaml_scenario("test_data_no_depreciation.yaml")
+
+    def test_onchange_category_id_no_depreciation_resets_method(self):
+        """Memilih kategori no_depreciation harus mereset method_number ke 0."""
+        account_asset = self.env["account.account"].create(
+            {
+                "name": "Test Asset Account OC",
+                "code": "TND_OC_A01",
+                "user_type_id": self.env.ref(
+                    "account.data_account_type_non_current_assets"
+                ).id,
+                "internal_type": "other",
+            }
+        )
+        category = self.env["fixed.asset.category"].create(
+            {
+                "name": "Land Category OC",
+                "code": "TND_OC_C01",
+                "no_depreciation": True,
+                "account_asset_id": account_asset.id,
+            }
+        )
+        form = Form(self.env["fixed.asset.asset"])
+        form.name = "Land Test OC"
+        form.category_id = category
+        self.assertEqual(form.method_number, 0)
+        self.assertFalse(form.prorata)

--- a/ssi_fixed_asset/views/fixed_asset_asset.xml
+++ b/ssi_fixed_asset/views/fixed_asset_asset.xml
@@ -96,6 +96,7 @@
                                 invisible="1"
                             />
                         <field name="move_line_check" invisible="1" />
+                        <field name="no_depreciation" invisible="1" />
                         <field
                                 name="category_id"
                                 attrs="{'required':[('type','=','normal')]}"
@@ -112,7 +113,7 @@
                                 name="value_depreciated"
                                 widget="monetary"
                                 options="{'currency_field': 'company_currency_id'}"
-                                attrs="{'invisible':[('type','=','view')]}"
+                                attrs="{'invisible':['|',('type','=','view'),('no_depreciation','=',True)]}"
                             />
                         <field
                                 name="value_residual"
@@ -159,7 +160,7 @@
                                     name="salvage_value"
                                     widget="monetary"
                                     options="{'currency_field': 'company_currency_id'}"
-                                    attrs="{'readonly':['|',('move_line_check','=',True),('state','!=','draft')]}"
+                                    attrs="{'readonly':['|',('move_line_check','=',True),('state','!=','draft')],'invisible':[('no_depreciation','=',True)]}"
                                 />
                             <field
                                     name="account_analytic_id"
@@ -173,6 +174,7 @@
                                     colspan="1"
                                     col="2"
                                     string="Depreciation Dates"
+                                    attrs="{'invisible': [('no_depreciation', '=', True)]}"
                                 >
                                 <field name="method_time" />
                                 <field
@@ -208,6 +210,7 @@
                                     colspan="1"
                                     col="2"
                                     string="Depreciation Method"
+                                    attrs="{'invisible': [('no_depreciation', '=', True)]}"
                                 >
                                   <field name="method" />
                                   <field
@@ -223,7 +226,11 @@
                             </group>
                         </group>
                     </page>
-                    <page name="page_depreciation" string="Depreciation Board">
+                    <page
+                            name="page_depreciation"
+                            string="Depreciation Board"
+                            attrs="{'invisible': [('no_depreciation', '=', True)]}"
+                        >
                         <div>
                             <button
                                     type="object"

--- a/ssi_fixed_asset/views/fixed_asset_category.xml
+++ b/ssi_fixed_asset/views/fixed_asset_category.xml
@@ -31,6 +31,7 @@
         <field name="arch" type="xml">
             <data>
                 <xpath expr="//field[@name='name']" position="after">
+                    <field name="no_depreciation" />
                     <field name="journal_id" />
                     <field name="method" />
                     <field name="method_time" />
@@ -55,10 +56,29 @@
                 <xpath expr="//notebook" position="inside">
                     <page name="accounting" string="Accounting">
                         <group name="accounting_1" colspan="4" col="2">
-                            <field name="journal_id" />
+                            <field name="no_depreciation" />
+                            <field
+                                name="journal_id"
+                                attrs="{
+                                    'invisible': [('no_depreciation', '=', True)],
+                                    'required': [('no_depreciation', '=', False)]
+                                }"
+                            />
                             <field name="account_asset_id" />
-                            <field name="account_depreciation_id" />
-                            <field name="account_expense_depreciation_id" />
+                            <field
+                                name="account_depreciation_id"
+                                attrs="{
+                                    'invisible': [('no_depreciation', '=', True)],
+                                    'required': [('no_depreciation', '=', False)]
+                                }"
+                            />
+                            <field
+                                name="account_expense_depreciation_id"
+                                attrs="{
+                                    'invisible': [('no_depreciation', '=', True)],
+                                    'required': [('no_depreciation', '=', False)]
+                                }"
+                            />
                         </group>
                         <group
                             name="accounting_2"
@@ -68,7 +88,11 @@
                             <field name="account_analytic_id" />
                         </group>
                     </page>
-                    <page name="depreciation_date" string="Depreciation Dates">
+                    <page
+                        name="depreciation_date"
+                        string="Depreciation Dates"
+                        attrs="{'invisible': [('no_depreciation', '=', True)]}"
+                    >
                         <group name="depreciation_date_1" colspan="4" col="2">
                             <field name="method_time" />
                             <field
@@ -78,7 +102,11 @@
                             <field name="method_period" />
                         </group>
                     </page>
-                    <page name="depreciation_method" string="Depreciation Method">
+                    <page
+                        name="depreciation_method"
+                        string="Depreciation Method"
+                        attrs="{'invisible': [('no_depreciation', '=', True)]}"
+                    >
                         <group name="depreciation_method_1" colspan="4" col="2">
                             <field name="method" />
                             <field


### PR DESCRIPTION
## Summary

- Menambahkan field `no_depreciation` pada `fixed.asset.category` untuk menandai kategori aset yang tidak didepresiasi (misal: tanah)
- Field `no_depreciation` di kategori membuat `journal_id`, `account_depreciation_id`, dan `account_expense_depreciation_id` tidak wajib diisi
- Field `no_depreciation` ter-propagate ke `fixed.asset.asset` melalui field related
- Method `_should_skip_compute_depreciation_board()` diekstrak agar bisa di-override modul lain
- `compute_depreciation_board()` melewati (skip) aset dengan `no_depreciation=True`
- View form kategori dan aset menyembunyikan section depresiasi ketika `no_depreciation=True`
- Unit test: 4 skenario YAML + 1 test onchange Form API

## Test plan

- [x] Unit test lokal lulus: `0 failed, 0 error(s)` pada semua 19 test
- [x] Skenario: buat kategori `no_depreciation=True` tanpa akun depresiasi
- [x] Skenario: field `no_depreciation` ter-propagate dari kategori ke aset
- [x] Skenario: `compute_depreciation_board` tidak menghasilkan baris depresiasi
- [x] Skenario: workflow penuh draft → confirm → approve → open tanpa error
- [x] Test onchange: memilih kategori `no_depreciation` mereset `method_number=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)